### PR TITLE
Correct imports to use library with python 3.10

### DIFF
--- a/safeopt/gp_opt.py
+++ b/safeopt/gp_opt.py
@@ -7,7 +7,12 @@ Authors: - Felix Berkenkamp (befelix at inf dot ethz dot ch)
 
 from __future__ import print_function, absolute_import, division
 
-from collections import Sequence
+try:
+    # for python < 3.10
+    from collections import Sequence
+except ImportError:
+    # for python >= 3.10
+    from collections.abc import Sequence
 from functools import partial
 
 import numpy as np

--- a/safeopt/utilities.py
+++ b/safeopt/utilities.py
@@ -6,7 +6,12 @@ Author: Felix Berkenkamp (befelix at inf dot ethz dot ch)
 
 from __future__ import print_function, absolute_import, division
 
-from collections import Sequence            # isinstance(...,Sequence)
+try:
+    # for python < 3.10
+    from collections import Sequence            # isinstance(...,Sequence)
+except ImportError:
+    # for python >= 3.10
+    from collections.abc import Sequence
 import numpy as np
 import scipy as sp
 import matplotlib.pyplot as plt


### PR DESCRIPTION
With Python 3.10 `Sequence` was moved to `collections.abc`. This PR ensures that the library can be used for Python < 3.10 as well as for Python >= 3.10.